### PR TITLE
Increase Version of Dependency: apple_maps_flutter to 1.3.0 -> 1.4.0

### DIFF
--- a/packages/platform_maps_flutter_apple/pubspec.yaml
+++ b/packages/platform_maps_flutter_apple/pubspec.yaml
@@ -20,7 +20,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  apple_maps_flutter: ^1.3.0
+  apple_maps_flutter: ^1.4.0
   platform_maps_flutter_platform_interface: ^1.0.0-beta
 
 dev_dependencies:


### PR DESCRIPTION
## Description

*This PR raises the version of the package: apple_maps_flutter to the current stable version of the dependency.*

## Reason for the adjustment

The change is necessary because otherwise, when building an IOS app, an error can occur within this library, which has been fixed with the current version.

## Bugfixes of this PR
I updated pubspec.yaml with an appropriate new version according to the apple_maps_flutter.